### PR TITLE
Switch to librarian-puppet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
-/modules/
-
 Gemfile.lock
+.tmp/
+modules/
+.librarian/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,14 @@
 language: ruby
-cache: bundler
+cache:
+  - bundler
+  - directories:
+    - $HOME/librarian-puppet
 
 env:
-  - PUPPET_VERSION="3.4.3"    # Version installed on Trusty
-  - PUPPET_VERSION="~> 3.8.0" # Latest version
+  global:
+    - LIBRARIAN_PUPPET_TMP="$HOME/librarian-puppet"
+  matrix:
+    - PUPPET_VERSION="3.4.3"    # Version installed on Trusty
+    - PUPPET_VERSION="~> 3.8.0" # Latest version
 
 # bundle install and rake run automatically by Travis.

--- a/Gemfile
+++ b/Gemfile
@@ -6,5 +6,5 @@ group :test do
   gem 'puppet-lint'
   gem 'rake'
   gem 'rspec-puppet'
-  gem 'r10k'
+  gem 'librarian-puppet'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -3,8 +3,10 @@ source 'https://rubygems.org'
 group :test do
   puppetversion = ENV.key?('PUPPET_VERSION') ? "#{ENV['PUPPET_VERSION']}" : ['>= 3.0.0','< 4.0']
   gem 'puppet', puppetversion
+
+  gem 'librarian-puppet'
   gem 'puppet-lint'
+  gem 'puppetlabs_spec_helper'
   gem 'rake'
   gem 'rspec-puppet'
-  gem 'librarian-puppet'
 end

--- a/Puppetfile
+++ b/Puppetfile
@@ -1,3 +1,7 @@
-mod 'puppetlabs/stdlib', '4.10.0'
-mod 'puppetlabs/apt', '2.2.1'
-mod 'deric/mesos', '0.6.4'
+#!/usr/bin/env ruby
+#^syntax detection
+
+forge "https://forgeapi.puppetlabs.com"
+
+# use dependencies defined in metadata.json
+metadata

--- a/Puppetfile.lock
+++ b/Puppetfile.lock
@@ -1,0 +1,15 @@
+FORGE
+  remote: https://forgeapi.puppetlabs.com
+  specs:
+    deric-mesos (0.6.4)
+      puppetlabs-apt (>= 2.1.0)
+      puppetlabs-stdlib (>= 4.2.0)
+    puppetlabs-apt (2.2.1)
+      puppetlabs-stdlib (< 5.0.0, >= 4.5.0)
+    puppetlabs-stdlib (4.10.0)
+
+DEPENDENCIES
+  deric-mesos (>= 0.6.4)
+  puppetlabs-apt (>= 2.1.0)
+  puppetlabs-stdlib (>= 4.2.0)
+

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,4 @@
+require 'puppetlabs_spec_helper/rake_tasks'
 require 'puppet-lint/tasks/puppet-lint'
 require 'rspec-puppet/rake_task'
 
@@ -5,5 +6,10 @@ Rake::Task[:lint].clear
 PuppetLint::RakeTask.new :lint do |config|
   config.ignore_paths = ["spec/**/*.pp", "vendor/**/*.pp", "modules/**/*.pp"]
 end
+
+task :librarian_spec_prep do
+  sh 'librarian-puppet install --path=spec/fixtures/modules/'
+end
+task :spec_prep => :librarian_spec_prep
 
 task :default => [:spec, :lint]

--- a/Rakefile
+++ b/Rakefile
@@ -8,7 +8,7 @@ PuppetLint::RakeTask.new :lint do |config|
 end
 
 task :librarian_spec_prep do
-  sh 'librarian-puppet install --verbose --path=spec/fixtures/modules/'
+  sh 'librarian-puppet install --path=spec/fixtures/modules/'
 end
 task :spec_prep => :librarian_spec_prep
 

--- a/Rakefile
+++ b/Rakefile
@@ -8,7 +8,7 @@ PuppetLint::RakeTask.new :lint do |config|
 end
 
 task :librarian_spec_prep do
-  sh 'librarian-puppet install --path=spec/fixtures/modules/'
+  sh 'librarian-puppet install --verbose --path=spec/fixtures/modules/'
 end
 task :spec_prep => :librarian_spec_prep
 


### PR DESCRIPTION
[librarian-puppet] has a bunch of advantages over r10k for custom puppet modules:
- Does dependency resolution
- Also downloads dependencies of dependencies
- Allows specifying a range of dependency versions
- Can read dependencies from module metadata file
