### PR TITLE
Disable/enable syslog (logger) output

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -75,9 +75,10 @@ class marathon::config(
     }
   )
 
-  # The --no-logger flag that disables syslog output must either be present or
-  # not at all (there is no --logger) flag. This means a mesos::property can't
-  # be used.
+  # The "--no-logger" flag that disables syslog output is used by Marathon's
+  # startup script, not Marathon itself, and so does not behave quite like other
+  # configuration options. Using a mesos::property would result in a "--logger"
+  # flag when syslog is true, which in this case is not a valid flag.
   $no_logger_ensure = $syslog ? {
     true  => absent,
     false => present,

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -9,6 +9,7 @@ class marathon::config(
   $zookeeper              = undef,
   $options                = { },
   $env_var                = { },
+  $syslog                 = true,
   $manage_logger          = true,
   $logger                 = 'logback',
   $log_dir                = '/var/log/marathon',
@@ -73,6 +74,19 @@ class marathon::config(
       service => undef,
     }
   )
+
+  # The --no-logger flag that disables syslog output must either be present or
+  # not at all (there is no --logger) flag. This means a mesos::property can't
+  # be used.
+  $no_logger_ensure = $syslog ? {
+    true  => absent,
+    false => present,
+  }
+  file { "${conf_dir}/?no-logger":
+    ensure => $no_logger_ensure,
+    owner  => $owner,
+    group  => $group,
+  }
 
   if $manage_logger {
     file { $log_dir:

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -33,6 +33,10 @@
 # [*env_var*]
 #   A hash of environment variables to export before starting Marathon.
 #
+# [*syslog*]
+#   Whether Marathon should log to syslog. This flag can be used independently
+#   of manage_logger. Marathon will log to syslog by default.
+#
 # [*manage_logger*]
 #   Whether or not to configure the logger for Marathon.
 #
@@ -86,6 +90,7 @@ class marathon(
   $zookeeper              = undef,
   $options                = {},
   $env_var                = {},
+  $syslog                 = true,
   $manage_logger          = true,
   $logger                 = 'logback',
   $log_dir                = '/var/log/marathon',
@@ -126,6 +131,7 @@ class marathon(
     zookeeper              => $zookeeper,
     options                => $options,
     env_var                => $env_var,
+    syslog                 => $syslog,
     manage_logger          => $manage_logger,
     logger                 => $logger,
     log_dir                => $log_dir,

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -207,6 +207,26 @@ describe 'marathon::config' do
             end
         end
       end
+
+      context 'syslog' do
+        describe 'when syslog is true' do
+          let(:params) { { :syslog => true } }
+          it do
+            is_expected.to contain_file('/etc/marathon/conf/?no-logger').with({
+              'ensure' => 'absent',
+            })
+          end
+        end
+
+        describe 'when syslog is false' do
+          let(:params) { { :syslog => false } }
+          it do
+            is_expected.to contain_file('/etc/marathon/conf/?no-logger').with({
+              'ensure' => 'present',
+            })
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Adding either `--no-logger` to the Marathon command or a file called `?no-logger` to the conf directory will disable the running of [`logger`](http://linux.die.net/man/1/logger) which spams syslog.
