### PR TITLE
pass log level settings as a hash

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -15,6 +15,7 @@ class marathon::config(
   $log_dir                = '/var/log/marathon',
   $log_filename           = 'marathon.log',
   $log_level              = 'info',
+  $log_levels             = {},
   $ulimit                 = undef,
   $mesos_auth_principal   = undef,
   $mesos_auth_secret      = undef,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -47,6 +47,11 @@
 # [*log_dir*]
 #   The directory to store log files.
 #
+# [*log_levels*]
+#   A hash for configuring log levels like:
+#     {'mesosphere.chaos' => 'ERROR'}
+#   List of possible classes can be found at http://marathon/logging
+#
 # [*log_filename*]
 #   The name of the logfile to store in the log directory.
 #
@@ -95,6 +100,7 @@ class marathon(
   $logger                 = 'logback',
   $log_dir                = '/var/log/marathon',
   $log_filename           = 'marathon.log',
+  $log_levels             = {},
   $java_home              = undef,
   $java_opts              = '-Xmx512m',
   $ulimit                 = undef,
@@ -110,6 +116,7 @@ class marathon(
   validate_bool($manage_logger)
   validate_hash($options)
   validate_hash($env_var)
+  validate_hash($log_levels)
   if $ulimit != undef {
     validate_integer($ulimit)
   }
@@ -136,6 +143,7 @@ class marathon(
     logger                 => $logger,
     log_dir                => $log_dir,
     log_filename           => $log_filename,
+    log_levels             => $log_levels,
     java_home              => $java_home,
     java_opts              => $java_opts,
     ulimit                 => $ulimit,

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -263,6 +263,17 @@ describe 'marathon::config' do
           it { is_expected.not_to contain_mesos__property('marathon_zk') }
         end
       end
+
+      context 'configure marathon\'s logging levels' do
+        let(:params) {{
+            :log_levels => { 'mesosphere.chaos.http' => 'ERROR'}
+          }}
+        it 'appends setting to logback.xml' do
+          is_expected.to contain_file('/etc/marathon/logback.xml')
+            .with_content(/\<logger name="mesosphere.chaos.http" level="ERROR"\/\>/)
+        end
+      end
+
     end
   end
 end

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -265,15 +265,18 @@ describe 'marathon::config' do
       end
 
       context 'configure marathon\'s logging levels' do
-        let(:params) {{
-            :log_levels => { 'mesosphere.chaos.http' => 'ERROR'}
-          }}
+        let(:params) do
+          {
+            :log_levels => {'mesosphere.chaos.http' => 'ERROR'}
+          }
+        end
         it 'appends setting to logback.xml' do
           is_expected.to contain_file('/etc/marathon/logback.xml')
-            .with_content(/\<logger name="mesosphere.chaos.http" level="ERROR"\/\>/)
+            .with_content(
+              /\<logger name="mesosphere.chaos.http" level="ERROR"\/\>/
+            )
         end
       end
-
     end
   end
 end

--- a/templates/logback.xml.erb
+++ b/templates/logback.xml.erb
@@ -21,5 +21,7 @@
   <root level="<%= @log_level %>">
     <appender-ref ref="FILE" />
   </root>
-
+  <% @log_levels.each do |key, level| -%>
+  <logger name="<%= key %>" level="<%= level %>"/>
+  <% end -%>
 </configuration>

--- a/templates/logback.xml.erb
+++ b/templates/logback.xml.erb
@@ -17,11 +17,10 @@
       <maxFileSize>10MB</maxFileSize>
     </triggeringPolicy>
   </appender>
-
+  <% @log_levels.each do |key, level| -%>
+  <logger name="<%= key %>" level="<%= level %>"/>
+  <% end %>
   <root level="<%= @log_level %>">
     <appender-ref ref="FILE" />
   </root>
-  <% @log_levels.each do |key, level| -%>
-  <logger name="<%= key %>" level="<%= level %>"/>
-  <% end -%>
 </configuration>


### PR DESCRIPTION
Allow adjusting marathon logging by passing a hash like:

```
log_levels => {
  mesosphere.marathon.api => 'DEBUG'
}
```

Feel free to change the name of the parameter, I couldn't come up with anything better than `log_levels`.
