### PR TITLE
add provider support

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -83,6 +83,10 @@
 #
 # [*service_ensure*]
 #   What state the service should be kept in - e.g. 'running'
+#
+# [*force_provider]
+# Service provider override, eg: upstart
+
 class marathon(
   $repo_manage            = true,
   $repo_source            = 'mesosphere',
@@ -109,7 +113,9 @@ class marathon(
   $mesos_auth_secret_file = '/etc/marathon/.secret',
 
   $service_manage         = true,
-  $service_ensure         = 'running'
+  $service_ensure         = 'running',
+
+  $force_provider         = undef
 ) {
 
   validate_bool($repo_manage)
@@ -153,8 +159,9 @@ class marathon(
   }
 
   class { 'marathon::service':
-    ensure => $service_ensure,
-    manage => $service_manage,
+    ensure         => $service_ensure,
+    manage         => $service_manage,
+    force_provider => $force_provider,
   }
 
   anchor { 'marathon::begin': }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -3,13 +3,24 @@
 class marathon::service (
   $manage = true,
   $ensure = 'running',
+  $force_provider = undef,
 ) {
   if $manage {
-    service { 'marathon':
-      ensure     => $ensure,
-      enable     => true,
-      hasrestart => true,
-      hasstatus  => true,
+    if $force_provider {
+      service { 'marathon':
+        ensure     => $ensure,
+        enable     => true,
+        hasrestart => true,
+        hasstatus  => true,
+        provider   => $force_provider,
+      }
+    }else{
+      service { 'marathon':
+        ensure     => $ensure,
+        enable     => true,
+        hasrestart => true,
+        hasstatus  => true,
+      }
     }
   }
 }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -6,21 +6,12 @@ class marathon::service (
   $force_provider = undef,
 ) {
   if $manage {
-    if $force_provider {
-      service { 'marathon':
-        ensure     => $ensure,
-        enable     => true,
-        hasrestart => true,
-        hasstatus  => true,
-        provider   => $force_provider,
-      }
-    }else{
-      service { 'marathon':
-        ensure     => $ensure,
-        enable     => true,
-        hasrestart => true,
-        hasstatus  => true,
-      }
+    service { 'marathon':
+      ensure     => $ensure,
+      enable     => true,
+      hasrestart => true,
+      hasstatus  => true,
+      provider   => $force_provider,
     }
   }
 }


### PR DESCRIPTION
marathon packed by mesosphere uses upstart on centos, by default it is init causing puppet failure, so need a way to override provider. 
